### PR TITLE
Chef task view and chef task save state fix

### DIFF
--- a/gml_GlobalScript_scr_tas_tools.txt
+++ b/gml_GlobalScript_scr_tas_tools.txt
@@ -256,6 +256,39 @@ function tas_savestate(slottosave) //gml_Script_tas_savestate
         }
     }
 	
+	// chef task variables
+	// they are separate because they are full of arrays and objects passed by reference so in the other save state loops they are just resored to themselves
+	// so this "manually" goes inside the task data objects and saves their values to be restored later
+	var saved_chef_task_vars = []
+	for (i = 0; i < array_length(obj_achievementtracker.achievements_notify); i++)
+	{
+		// achievements_notify contains all the chef task data
+		var task_data = obj_achievementtracker.achievements_notify[i]
+		// see function "achievement_add_variable" to see other variables in chef task variable data
+		// value is enough for save state so only that is saved
+		var task_vars_for_state = 
+		{
+			value: 0
+		}
+
+		// the the variables and save them
+		var chef_task_vars_names = ds_map_keys_to_array(task_data.variables)
+		for (j = 0; j < array_length(chef_task_vars_names); j++)
+		{
+			var variable_to_save = ds_map_find_value(task_data.variables, chef_task_vars_names[j])
+			task_vars_for_state.value = variable_to_save.value
+		}
+		// save the full chef task data
+		array_push(saved_chef_task_vars, 
+		{
+			name: task_data.name,
+			creation_code: task_data.creation_code,
+			func: task_data.func,
+			unlocked: task_data.unlocked,
+			variables: task_vars_for_state
+		})
+	}
+
 	//Save state as array
 	// index : value
 	// 0 : room name
@@ -268,6 +301,7 @@ function tas_savestate(slottosave) //gml_Script_tas_savestate
 	// 7 : culled objects (array)
 	// 8 : current room save state
 	// 9 : last room save state
+	// 10: chef task variables
 
 	//Remove chain of savestates from saved save states
 	var current = global.savestates[10]
@@ -289,7 +323,8 @@ function tas_savestate(slottosave) //gml_Script_tas_savestate
 	culled_list,
 	culled_objects,
 	current,
-	last
+	last,
+	saved_chef_task_vars
 	]
 	
     global.savestates[argument0] = saveinfo

--- a/gml_Object_obj_tas_tool_Alarm_0.txt
+++ b/gml_Object_obj_tas_tool_Alarm_0.txt
@@ -241,6 +241,28 @@ if instance_exists(obj_spaceblockswitch)
 //Set camera position
 camera_set_view_pos(view_camera[0], save[3], save[4])
 
+// load chef task data
+// note that this is assuming the order and length of achievements_notify is the exact same of save[10] (which should be the case)
+for (i = 0; i < array_length(obj_achievementtracker.achievements_notify); i++)
+{
+	var chef_task_data_to_load = save[10][i]
+	var real_chef_task_data = obj_achievementtracker.achievements_notify[i]
+	// restore general data
+	real_chef_task_data.name = chef_task_data_to_load.name
+	real_chef_task_data.creation_code = chef_task_data_to_load.creation_code
+	real_chef_task_data.func = chef_task_data_to_load.func
+	real_chef_task_data.unlocked = chef_task_data_to_load.unlocked
+	// restore value of variables
+	var chef_task_vars_names = ds_map_keys_to_array(real_chef_task_data.variables)
+	for (j = 0; j < array_length(chef_task_vars_names); j++)
+	{
+		var variable_to_write_to = ds_map_find_value(real_chef_task_data.variables, chef_task_vars_names[j])
+		var variable_to_load = chef_task_data_to_load.variables
+		if ((variable_to_write_to != undefined))
+			variable_to_write_to.value = variable_to_load.value
+	}
+}
+
 create_transformation_tip(("Loaded slot " + string(slot)))
 
 global.loadingstate = 0

--- a/obj_practice_mod_Create_0.txt
+++ b/obj_practice_mod_Create_0.txt
@@ -20,3 +20,307 @@ scr_init_input_practice()
 
 //Sets global variables
 scr_initpracticeinput()
+
+//specify what chef task variables to show per level
+chef_task_vars = [
+{
+    level: "entrance",
+    task_name: "entrance1",
+    variable: "entr1count",
+    text: "JOHN GUTTED"
+}
+, 
+{
+    level: "medieval",
+    task_name: "medieval1",
+    variable: "med1hurt",
+    text: "BUMPED WALL"
+}
+, 
+{
+    level: "medieval",
+    task_name: "medieval2",
+    variable: "med2count",
+    text: "SPOONKNIGHT"
+}
+, 
+{
+    level: "ruin",
+    task_name: "ruin1",
+    variable: "ruin1hurt",
+    text: "HURT BY BOMB"
+}
+, 
+{
+    level: "ruin",
+    task_name: "ruin3",
+    variable: "ruin3count",
+    text: "DELICACY"
+}
+, 
+{
+    level: "dungeon",
+    task_name: "dungeon1",
+    variable: "dun1hurt",
+    text: "HOT SAUCE HURT"
+}
+, 
+{
+    level: "badland",
+    task_name: "badland2",
+    variable: "bad2count",
+    text: "VIOLENCE"
+}
+, 
+{
+    level: "badland",
+    task_name: "badland3",
+    variable: "bad3hurt",
+    text: "ALIEN COW"
+}
+, 
+{
+    level: "graveyard",
+    task_name: "graveyard1",
+    variable: "grav1hurt",
+    text: "GHOSTED"
+}
+, 
+{
+    level: "graveyard",
+    task_name: "graveyard2",
+    variable: "grav2count",
+    text: "PRETEND GHOST"
+}
+, 
+{
+    level: "graveyard",
+    task_name: "graveyard3",
+    variable: "grav3count",
+    text: "ALIVE"
+}
+, 
+{
+    level: "farm",
+    task_name: "farm1",
+    variable: "f1_count",
+    text: "NO ONE SAFE"
+}
+, 
+{
+    level: "farm",
+    task_name: "farm3",
+    variable: "f3_hurted",
+    text: "GOOD EGG"
+}
+, 
+{
+    level: "saloon",
+    task_name: "saloon1",
+    variable: "s1_beer",
+    text: "NON ALCOHOLIC"
+}
+, 
+{
+    level: "saloon",
+    task_name: "saloon2",
+    variable: "s2_count",
+    text: "ALREADY PRESSED"
+}
+, 
+{
+    level: "saloon",
+    task_name: "saloon3",
+    variable: "s3_count",
+    text: "ROYAL FLUSH"
+}
+, 
+{
+    level: "plage",
+    task_name: "plage2",
+    variable: "b2_count",
+    text: "X"
+}
+, 
+{
+    level: "plage",
+    task_name: "plage3",
+    variable: "b3_hurt",
+    text: "DEMOLITION"
+}
+, 
+{
+    level: "forest",
+    task_name: "forest2",
+    variable: "fo2_count",
+    text: "LUMBERJACK"
+}
+, 
+{
+    level: "space",
+    task_name: "space1",
+    variable: "sp1_hit",
+    text: "TURBO TUNNEL"
+}
+, 
+{
+    level: "space",
+    task_name: "space2",
+    variable: "sp2_count",
+    text: "BLAST EM"
+}
+, 
+{
+    level: "space",
+    task_name: "space3",
+    variable: "space3count",
+    text: "MAN METEOR"
+}
+, 
+{
+    level: "minigolf",
+    task_name: "minigolf1",
+    variable: "g1_count",
+    text: "PRIMO GOLFER"
+}
+, 
+{
+    level: "minigolf",
+    task_name: "minigolf2",
+    variable: "g2_count",
+    text: "NICE SHOT"
+}
+, 
+{
+    level: "street",
+    task_name: "street2",
+    variable: "st2_count",
+    text: "STRIKE"
+}
+, 
+{
+    level: "street",
+    task_name: "street3",
+    variable: "st3_count",
+    text: "SAY OINK"
+}
+, 
+{
+    level: "sewer",
+    task_name: "sewer1",
+    variable: "sw1_killed",
+    text: "CANT FOOL"
+}
+, 
+{
+    level: "sewer",
+    task_name: "sewer2",
+    variable: "sw2_count",
+    text: "FOOD CLAN"
+}
+, 
+{
+    level: "sewer",
+    task_name: "sewer3",
+    variable: "sw3_count",
+    text: "PENNY PINCHER"
+}
+, 
+{
+    level: "industrial",
+    task_name: "industrial1",
+    variable: "i1_count",
+    text: "UNFLATTENING"
+}
+, 
+{
+    level: "industrial",
+    task_name: "industrial2",
+    variable: "i2_count",
+    text: "WHOOP THIS"
+}
+, 
+{
+    level: "industrial",
+    task_name: "industrial3",
+    variable: "i3_count",
+    text: "ONLY ONE"
+}
+, 
+{
+    level: "freezer",
+    task_name: "freezer1",
+    variable: "fr1_count",
+    text: "NUGGETS"
+}
+, 
+{
+    level: "freezer",
+    task_name: "freezer2",
+    variable: "fr2_count",
+    text: "GREETINGS"
+}
+, 
+{
+    level: "freezer",
+    task_name: "freezer3",
+    variable: "fr3_fall",
+    text: "CLIMBER"
+}
+, 
+{
+    level: "chateau",
+    task_name: "chateau1",
+    variable: "ch1_count",
+    text: "CROSS"
+}
+, 
+{
+    level: "chateau",
+    task_name: "chateau2",
+    variable: "ch2_hurt",
+    text: "HAUNTED"
+}
+, 
+{
+    level: "chateau",
+    task_name: "chateau3",
+    variable: "ch3_count",
+    text: "SKULL"
+}
+, 
+{
+    level: "kidsparty",
+    task_name: "kidsparty1",
+    variable: "kp1_count",
+    text: "AND THIS"
+}
+, 
+{
+    level: "kidsparty",
+    task_name: "kidsparty2",
+    variable: "kp2_count",
+    text: "SLEEP"
+}
+, 
+{
+    level: "kidsparty",
+    task_name: "kidsparty3",
+    variable: "kp3_hurted",
+    text: "SPARED"
+}
+, 
+{
+    level: "war",
+    task_name: "war1",
+    variable: "war1hurt",
+    text: "VETERAN"
+}
+, 
+{
+    level: "war",
+    task_name: "war2",
+    variable: "war2_missed",
+    text: "SHARP"
+}
+]

--- a/obj_practice_mod_Draw_64.txt
+++ b/obj_practice_mod_Draw_64.txt
@@ -108,14 +108,34 @@ if variable_global_exists("smallfont")
 																															   
                 draw_sprite(spr_controlicons, 10, (obj_screensizer.actual_width - 90), input_display_height)
   		
-			//Score
+			
 			if (global.showstats > 1)
 			{
+				//Score
 				var truescore = (global.collect + global.collectN)
 				var collectval = concat("SCORE: ", truescore, " P: ", global.collect, " N: ", global.collectN)
 				var comboval = concat("COMBO: ", global.comboscore)
 				draw_text(8, 80, collectval)
 				draw_text(8, 104, comboval)
+
+				//Chef task vars
+				var var_text_offset = 0
+				for (i = 0; i < array_length(obj_achievementtracker.achievements_notify); i++)
+				{
+					var real_task_data = obj_achievementtracker.achievements_notify[i]
+					for (var j = 0; j < array_length(chef_task_vars); j++)
+					{
+						if ((chef_task_vars[j].task_name == real_task_data.name) && (chef_task_vars[j].level == global.leveltosave))
+						{
+							var variable_for_task = ds_map_find_value(real_task_data.variables, chef_task_vars[j].variable)
+							if ((variable_for_task != undefined))
+							{
+								draw_text(10, ((var_text_offset * 24) + 128), ((chef_task_vars[j].text + ": ") + string(variable_for_task.value)))
+								var_text_offset += 1
+							}
+						}
+					}
+				}
 			}
 		
 			//Roomname and current sprite


### PR DESCRIPTION
Note that this will require UndertaleModTool v0.6.1.0, or the community edition for structs support.

This PR adds text below the combo / score text that shows chef task variables relevant to the current level, it will dynamically show only the current level variables. It also fixes the save states not restoring chef task data, forcing players to replay levels to test chef tasks or accidentally triggering them.